### PR TITLE
Update spring-cloud-netflix.adoc

### DIFF
--- a/docs/src/main/asciidoc/spring-cloud-netflix.adoc
+++ b/docs/src/main/asciidoc/spring-cloud-netflix.adoc
@@ -629,11 +629,11 @@ be slightly more than three seconds.
 [[netflix-hystrix-dashboard-starter]]
 === How to Include the Hystrix Dashboard
 
-To include the Hystrix Dashboard in your project, use the starter with a group ID of  `org.springframework.cloud` and an artifact ID of `spring-cloud-starter-netflix-hystrix-dashboard`.
+To include the Hystrix Dashboard in your project, use the starter with a group ID of  `org.springframework.cloud` and an artifact ID of `spring-cloud-starter-netflix-hystrix-dashboard`.  You also must include Spring Boot's Actuator dependency. 
 See the http://projects.spring.io/spring-cloud/[Spring Cloud Project page] for details on setting up your build system with the current Spring Cloud Release Train.
 
-To run the Hystrix Dashboard, annotate your Spring Boot main class with `@EnableHystrixDashboard`.
-Then visit `/hystrix` and point the dashboard to an individual instance's `/hystrix.stream` endpoint in a Hystrix client application.
+To run the Hystrix Dashboard, annotate your Spring Boot main class with `@EnableHystrixDashboard`.  You also must allow Actuator to expose the stream by setting management.endpoints.web.exposure.include=hystrix.stream.
+Then visit `/hystrix` and point the dashboard to an individual instance's `actuator/hystrix.stream` endpoint in a Hystrix client application.
 
 NOTE: When connecting to a `/hystrix.stream` endpoint that uses HTTPS, the certificate used by the server must be trusted by the JVM.
 If the certificate is not trusted, you must import the certificate into the JVM in order for the Hystrix Dashboard to make a successful connection to the stream endpoint.


### PR DESCRIPTION
Minor fix to hystrix dashboard section: actuator now controls the hystrix stream, so the management endpoint for the hysteria stream needs to be included, and the stream is access by actuator/hystrix.stream